### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/external/bluetooth/bluedroid/stack/include/btm_ble_api.h
+++ b/external/bluetooth/bluedroid/stack/include/btm_ble_api.h
@@ -913,7 +913,7 @@ BTM_API extern void BTM_BleReadAdvParams (UINT16 *adv_int_min, UINT16 *adv_int_m
 **
 ** Function         BTM_BleObtainVendorCapabilities
 **
-** Description      This function is called to obatin vendor capabilties
+** Description      This function is called to obatin vendor capabilities
 **
 ** Parameters       p_cmn_vsc_cb - Returns the vednor capabilities
 **

--- a/external/chromium_org/gpu/command_buffer/client/gles2_implementation.h
+++ b/external/chromium_org/gpu/command_buffer/client/gles2_implementation.h
@@ -588,7 +588,7 @@ class GLES2_IMPL_EXPORT GLES2Implementation
 
   bool IsExtensionAvailable(const char* ext);
 
-  // Caches certain capabilties state. Return true if cached.
+  // Caches certain capabilities state. Return true if cached.
   bool SetCapabilityState(GLenum cap, bool enabled);
 
   IdHandlerInterface* GetIdHandler(int id_namespace) const;

--- a/external/llvm/include/llvm/Analysis/BranchProbabilityInfo.h
+++ b/external/llvm/include/llvm/Analysis/BranchProbabilityInfo.h
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass is used to evaluate branch probabilties.
+// This pass is used to evaluate branch probabilities.
 //
 //===----------------------------------------------------------------------===//
 

--- a/external/llvm/include/llvm/CodeGen/MachineBranchProbabilityInfo.h
+++ b/external/llvm/include/llvm/CodeGen/MachineBranchProbabilityInfo.h
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass is used to evaluate branch probabilties on machine basic blocks.
+// This pass is used to evaluate branch probabilities on machine basic blocks.
 //
 //===----------------------------------------------------------------------===//
 

--- a/frameworks/base/core/java/android/net/NetworkAgent.java
+++ b/frameworks/base/core/java/android/net/NetworkAgent.java
@@ -68,7 +68,7 @@ public abstract class NetworkAgent extends Handler {
 
     /**
      * Sent by the NetworkAgent to ConnectivityService to pass the current
-     * NetworkCapabilties.
+     * NetworkCapabilities.
      * obj = NetworkCapabilities
      */
     public static final int EVENT_NETWORK_CAPABILITIES_CHANGED = BASE + 2;

--- a/frameworks/base/media/java/android/media/AudioManager.java
+++ b/frameworks/base/media/java/android/media/AudioManager.java
@@ -2284,7 +2284,7 @@ public class AudioManager {
      *  @param l the listener to be notified of audio focus changes
      *  @param streamType the main audio stream type affected by the focus request
      *  @param durationHint use {@link #AUDIOFOCUS_GAIN_TRANSIENT} to indicate this focus request
-     *      is temporary, and focus will be abandonned shortly. Examples of transient requests are
+     *      is temporary, and focus will be abandoned shortly. Examples of transient requests are
      *      for the playback of driving directions, or notifications sounds.
      *      Use {@link #AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK} to indicate also that it's ok for
      *      the previous focus owner to keep playing if it ducks its audio output.

--- a/frameworks/opt/net/wifi/service/tools/halutil/halutil.cpp
+++ b/frameworks/opt/net/wifi/service/tools/halutil/halutil.cpp
@@ -311,7 +311,7 @@ static int rttCmdId;
 static bool startScan( void (*pfnOnResultsAvailable)(wifi_request_id, unsigned),
                        int max_ap_per_scan, int base_period, int report_threshold) {
 
-    /* Get capabilties */
+    /* Get capabilities */
     wifi_gscan_capabilities capabilities;
     int result = wifi_get_gscan_capabilities(wlan0Handle, &capabilities);
     if (result < 0) {

--- a/frameworks/wilhelm/tests/examples/xaVideoDecoderCapabilities.cpp
+++ b/frameworks/wilhelm/tests/examples/xaVideoDecoderCapabilities.cpp
@@ -303,7 +303,7 @@ int main(int argc, char* const argv[])
     XAresult    result;
     XAObjectItf sl;
 
-    fprintf(stdout, "OpenMAX AL test %s: exercises SLAudioDecoderCapabiltiesItf ", argv[0]);
+    fprintf(stdout, "OpenMAX AL test %s: exercises SLAudioDecoderCapabilitiesItf ", argv[0]);
     fprintf(stdout, "and displays the list of supported video decoders, and for each, lists the ");
     fprintf(stdout, "profile / levels combinations, that map to the constants defined in ");
     fprintf(stdout, "\"XA_VIDEOPROFILE and XA_VIDEOLEVEL\" section of the specification\n\n");

--- a/linux/kernel/Documentation/ABI/testing/sysfs-bus-umc
+++ b/linux/kernel/Documentation/ABI/testing/sysfs-bus-umc
@@ -9,7 +9,7 @@ Description:
                 Controller (UMC).
 
                 The umc bus presents each of the individual
-                capabilties as a device.
+                capabilities as a device.
 
 What:           /sys/bus/umc/devices/.../capability_id
 Date:           July 2008

--- a/linux/kernel/Documentation/sound/alsa/seq_oss.html
+++ b/linux/kernel/Documentation/sound/alsa/seq_oss.html
@@ -105,7 +105,7 @@ if you use an AWE64 card, you'll see like the following:
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; synth 0: [EMU8000]
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; type 0x1 : subtype 0x20 : voices 32
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; capabilties : ioctl enabled / load_patch enabled
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; capabilities : ioctl enabled / load_patch enabled
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Number of MIDI devices: 3
 

--- a/linux/kernel/drivers/gpu/drm/i915/hdmi_audio_if.c
+++ b/linux/kernel/drivers/gpu/drm/i915/hdmi_audio_if.c
@@ -256,7 +256,7 @@ static int hdmi_audio_get_caps(enum had_caps_list get_element,
  * e.g. Audio INT.
  */
 static int hdmi_audio_set_caps(enum had_caps_list set_element,
-			void *capabilties)
+			void *capabilities)
 {
 	struct drm_device *dev = hdmi_priv->dev;
 	struct drm_i915_private *dev_priv =
@@ -284,13 +284,13 @@ static int hdmi_audio_set_caps(enum had_caps_list set_element,
 		break;
 
 	case HAD_SET_ENABLE_AUDIO_INT:
-		if (*((u32 *)capabilties) & HDMI_AUDIO_UNDERRUN)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_UNDERRUN)
 			int_masks |= I915_HDMI_AUDIO_UNDERRUN_ENABLE;
 		dev_priv->hdmi_audio_interrupt_mask |= int_masks;
 		i915_enable_hdmi_audio_int(dev);
 		break;
 	case HAD_SET_DISABLE_AUDIO_INT:
-		if (*((u32 *)capabilties) & HDMI_AUDIO_UNDERRUN)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_UNDERRUN)
 			int_masks |= I915_HDMI_AUDIO_UNDERRUN_ENABLE;
 		dev_priv->hdmi_audio_interrupt_mask &= ~int_masks;
 

--- a/linux/kernel/drivers/gpu/drm/i915/hdmi_audio_if.h
+++ b/linux/kernel/drivers/gpu/drm/i915/hdmi_audio_if.h
@@ -77,9 +77,9 @@ struct hdmi_audio_registers_ops {
 
 struct hdmi_audio_query_set_ops {
 	int (*hdmi_audio_get_caps) (enum had_caps_list query_element,
-			void *capabilties);
+			void *capabilities);
 	int (*hdmi_audio_set_caps) (enum had_caps_list set_element,
-			void *capabilties);
+			void *capabilities);
 };
 
 typedef struct hdmi_audio_event {

--- a/linux/kernel/drivers/staging/dgrp/drp.h
+++ b/linux/kernel/drivers/staging/dgrp/drp.h
@@ -570,7 +570,7 @@ enum dgrp_nd_state_t {
 
 #define NR_ECHO		0x0001		/* Server echo packet */
 #define NR_IDENT	0x0002		/* Server Product ID */
-#define NR_CAPABILITY	0x0004		/* Server Capabilties */
+#define NR_CAPABILITY	0x0004		/* Server Capabilities */
 #define NR_VPD		0x0008		/* Server VPD, if any */
 #define NR_PASSWORD	0x0010		/* Server Password */
 

--- a/linux/kernel/security/commoncap.c
+++ b/linux/kernel/security/commoncap.c
@@ -741,7 +741,7 @@ int cap_task_fix_setuid(struct cred *new, const struct cred *old, int flags)
 		break;
 
 	case LSM_SETID_FS:
-		/* juggle the capabilties to follow FSUID changes, unless
+		/* juggle the capabilities to follow FSUID changes, unless
 		 * otherwise suppressed
 		 *
 		 * FIXME - is fsuser used for all CAP_FS_MASK capabilities?

--- a/linux/modules/intel_media/display/pnw/drv/mdfld_hdmi_audio.c
+++ b/linux/modules/intel_media/display/pnw/drv/mdfld_hdmi_audio.c
@@ -215,7 +215,7 @@ static int mid_hdmi_audio_get_caps(enum had_caps_list get_element, void *capabil
  * used to set the HDMI audio capabilities.
  * e.g. Audio INT.
  */
-static int mid_hdmi_audio_set_caps(enum had_caps_list set_element, void *capabilties)
+static int mid_hdmi_audio_set_caps(enum had_caps_list set_element, void *capabilities)
 {
 	struct drm_device *dev = hdmi_priv->dev;
 	struct drm_psb_private *dev_priv = (struct drm_psb_private *) dev->dev_private;
@@ -250,20 +250,20 @@ static int mid_hdmi_audio_set_caps(enum had_caps_list set_element, void *capabil
 		}
 		break;
 	case HAD_SET_ENABLE_AUDIO_INT:
-		if (*((u32 *)capabilties) & HDMI_AUDIO_UNDERRUN)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_UNDERRUN)
 			int_masks |= PIPE_HDMI_AUDIO_UNDERRUN;
 
-		if (*((u32 *)capabilties) & HDMI_AUDIO_BUFFER_DONE)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_BUFFER_DONE)
 			int_masks |= PIPE_HDMI_AUDIO_BUFFER_DONE;
 
 		dev_priv->hdmi_audio_interrupt_mask |= int_masks;
 		mid_irq_enable_hdmi_audio(dev);
 		break;
 	case HAD_SET_DISABLE_AUDIO_INT:
-		if (*((u32 *)capabilties) & HDMI_AUDIO_UNDERRUN)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_UNDERRUN)
 			int_masks |= PIPE_HDMI_AUDIO_UNDERRUN;
 
-		if (*((u32 *)capabilties) & HDMI_AUDIO_BUFFER_DONE)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_BUFFER_DONE)
 			int_masks |= PIPE_HDMI_AUDIO_BUFFER_DONE;
 
 		dev_priv->hdmi_audio_interrupt_mask &= ~int_masks;

--- a/linux/modules/intel_media/display/pnw/drv/mdfld_hdmi_audio_if.h
+++ b/linux/modules/intel_media/display/pnw/drv/mdfld_hdmi_audio_if.h
@@ -63,8 +63,8 @@ struct  hdmi_audio_registers_ops {
 };
 
 struct hdmi_audio_query_set_ops {
-	int (*hdmi_audio_get_caps)(enum had_caps_list query_element , void *capabilties);
-	int (*hdmi_audio_set_caps)(enum had_caps_list set_element , void *capabilties);
+	int (*hdmi_audio_get_caps)(enum had_caps_list query_element , void *capabilities);
+	int (*hdmi_audio_set_caps)(enum had_caps_list set_element , void *capabilities);
 };
 
 typedef struct hdmi_audio_event {

--- a/linux/modules/intel_media/display/tng/drv/mdfld_hdmi_audio.c
+++ b/linux/modules/intel_media/display/tng/drv/mdfld_hdmi_audio.c
@@ -244,7 +244,7 @@ static int mid_hdmi_audio_get_caps(
  */
 static int mid_hdmi_audio_set_caps(
 				enum had_caps_list set_element,
-				void *capabilties)
+				void *capabilities)
 {
 	struct drm_device *dev = hdmi_priv->dev;
 	struct drm_psb_private *dev_priv =
@@ -290,20 +290,20 @@ static int mid_hdmi_audio_set_caps(
 		}
 		break;
 	case HAD_SET_ENABLE_AUDIO_INT:
-		if (*((u32 *)capabilties) & HDMI_AUDIO_UNDERRUN)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_UNDERRUN)
 			int_masks |= PIPE_HDMI_AUDIO_UNDERRUN;
 
-		if (*((u32 *)capabilties) & HDMI_AUDIO_BUFFER_DONE)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_BUFFER_DONE)
 			int_masks |= PIPE_HDMI_AUDIO_BUFFER_DONE;
 
 		dev_priv->hdmi_audio_interrupt_mask |= int_masks;
 		mid_irq_enable_hdmi_audio(dev);
 		break;
 	case HAD_SET_DISABLE_AUDIO_INT:
-		if (*((u32 *)capabilties) & HDMI_AUDIO_UNDERRUN)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_UNDERRUN)
 			int_masks |= PIPE_HDMI_AUDIO_UNDERRUN;
 
-		if (*((u32 *)capabilties) & HDMI_AUDIO_BUFFER_DONE)
+		if (*((u32 *)capabilities) & HDMI_AUDIO_BUFFER_DONE)
 			int_masks |= PIPE_HDMI_AUDIO_BUFFER_DONE;
 
 		dev_priv->hdmi_audio_interrupt_mask &= ~int_masks;

--- a/linux/modules/intel_media/display/tng/drv/mdfld_hdmi_audio_if.h
+++ b/linux/modules/intel_media/display/tng/drv/mdfld_hdmi_audio_if.h
@@ -66,9 +66,9 @@ struct  hdmi_audio_registers_ops {
 
 struct hdmi_audio_query_set_ops {
 	int (*hdmi_audio_get_caps)(enum had_caps_list query_element,
-					void *capabilties);
+					void *capabilities);
 	int (*hdmi_audio_set_caps)(enum had_caps_list set_element,
-					void *capabilties);
+					void *capabilities);
 };
 
 typedef struct hdmi_audio_event {

--- a/linux/modules/intel_media/hdmi_audio/intel_mid_hdmi_audio.h
+++ b/linux/modules/intel_media/hdmi_audio/intel_mid_hdmi_audio.h
@@ -611,8 +611,8 @@ void had_build_channel_allocation_map(struct snd_intelhad *intelhaddata);
 
 /* Register access functions */
 inline int had_get_hwstate(struct snd_intelhad *intelhaddata);
-inline int had_get_caps(enum had_caps_list query_element , void *capabilties);
-inline int had_set_caps(enum had_caps_list set_element , void *capabilties);
+inline int had_get_caps(enum had_caps_list query_element , void *capabilities);
+inline int had_set_caps(enum had_caps_list set_element , void *capabilities);
 inline int had_read_register(uint32_t reg_addr, uint32_t *data);
 inline int had_write_register(uint32_t reg_addr, uint32_t data);
 inline int had_read_modify(uint32_t reg_addr, uint32_t data, uint32_t mask);

--- a/packages/apps/InCallUI/src/com/android/incallui/VideoCallPresenter.java
+++ b/packages/apps/InCallUI/src/com/android/incallui/VideoCallPresenter.java
@@ -86,7 +86,7 @@ public class VideoCallPresenter extends Presenter<VideoCallPresenter.VideoCallUi
         private static final int CAMERA_SET = 1;
 
         /**
-         * The camera capabilties have been received from telephony, but the surface has not yet
+         * The camera capabilities have been received from telephony, but the surface has not yet
          * been set on the {@link VideoCall}.
          */
         private static final int CAPABILITIES_RECEIVED = 2;

--- a/sdk/files/typos/typos-en.txt
+++ b/sdk/files/typos/typos-en.txt
@@ -341,7 +341,7 @@ andriod->android
 #     License; this License is not intended to restrict the license of any
 #     rights under applicable law.
 
-abandonned->abandoned
+abandoned->abandoned
 aberation->aberration
 abilties->abilities
 abilty->ability

--- a/sdk/files/typos/typos-en.txt
+++ b/sdk/files/typos/typos-en.txt
@@ -343,7 +343,7 @@ andriod->android
 
 abandoned->abandoned
 aberation->aberration
-abilties->abilities
+abilities->abilities
 abilty->ability
 abondon->abandon
 abbout->about


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
